### PR TITLE
Added Friboo under "Service Toolkits/Clojure" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated list of Microservice Architecture related principles and technologies.
 
 - [Compojure](https://github.com/weavejester/compojure) - A concise routing library for Ring/Clojure.
 - [Duct](https://github.com/weavejester/duct) - Minimal framework for building web applications in Clojure, with a strong emphasis on simplicity.
+- [Friboo](https://github.com/zalando/friboo) - Utility library for writing microservices in Clojure, with support for Swagger and OAuth.
 - [Liberator](http://clojure-liberator.github.io/liberator/) - Library that helps you expose your data as resources while automatically complying with all the relevant requirements of the HTTP specification.
 - [Modularity](https://modularity.org/) - JUXT's Clojure-based modular system.
 - [System](https://github.com/danielsz/system) - Built on top of Stuart Sierra's component library, offers a set of readymade components.


### PR DESCRIPTION
Friboo (https://github.com/zalando/friboo) is an open-source utility library for writing microservices in Clojure, with support for Swagger and OAuth.