### PR TITLE
Added crufter/puller, a container deployment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Graphite, InfluxDB & OpenTSDB.
 - [Jenkins](http://jenkins-ci.org/) - Extensible open source continuous integration server.
 - [Nscale](https://github.com/nearform/nscale) - Open toolkit supporting configuration, build and deployment of connected container sets.
 - [Project 6](https://github.com/DatawiseIO/Project6) - Software for deploying and managing Docker containers across a cluster of hosts, with a focus on simplifying network and storage configurations for on-premises environments.
+- [Puller](https://github.com/crufter/puller) - A very simple, distributed tool to deploy and do CI with Docker containers.
 - [Rancher](https://github.com/rancher/rancher) - Open source platform for operating Docker in production.
 - [RPM Maven](http://mojo.codehaus.org/rpm-maven-plugin/) - Allows artifacts from one or more projects to be packaged in an RPM for distribution.
 


### PR DESCRIPTION
We use puller, go micro, docker and consul in our microservices stack. Works like a charm.