### PR TITLE
Add golang Nano framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Kite](https://github.com/koding/kite) - Microservices framework in Go.
 - [Libchan](https://github.com/docker/libchan) - Ultra-lightweight networking library which lets network services communicate in the same way that goroutines communicate using channels.
 - [Micro](https://github.com/micro/micro) - A microservices toolchain in Go.
+- [Nano](https://github.com/pasztorpisti/nano) - A minimalistic, transport-agnostic and testing-friendly microservice framework.
 - [Negroni](https://github.com/codegangsta/negroni) - Idiomatic HTTP middleware for Golang.
 - [Neutrino](https://github.com/neutrinoapp/neutrino) - Realtime/REST backend service.
 - [RPCX](https://github.com/smallnest/rpcx) - A distributed RPC service framework based on NET/RPC like Alibaba Dubbo and Weibo Motan.


### PR DESCRIPTION
Nano is an extremely small and simple "microservice framework" that promotes the do-it-yourself philosophy of golang without providing a lot of features (just like the Flask library for python that started out as a joke). It defines a few interfaces to force developers using a specific source code structure that allows services to be compiled into the same executable if necessary. I'd rather call this repo as a minimalistic reference implementation of this basic idea than a "framework" that is a curse word in golang. :-) The promoted source code structure has the following benefits:

- In this "framework" a service is a unit of business logic and it allows you to compile your services into a single monolithic executable before you decide to go for a more complex infrastructure setup where you compile each service (or subsets of services) into separate server executables. In fact, you can include the same services into a monolithic executable and separate per-service executables at the same time. Sometimes using a single executable is more practical. This solution sympathises with "Fallacy number 5" of the [Microservices – Please, don’t](http://basho.com/posts/technical/microservices-please-dont/) article and allows one to switch between monolith and microservices easily while the given interfaces of the nano framework enforce developers to implement their services as separated logical units.
- Being able to compile services into a single executable (or test executable) makes testing business logic (and mocking whole services) unusually easy by simply using the go testing framework and writing go test sources (that is executed by the the go testing framework). For business logic (service) tests there is no need to write servers, to deploy servers or to set up an infrastructure.