### PR TITLE
Add Fission Workflows to frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Vert.X](http://vertx.io/) - Toolkit for building reactive applications on the JVM.
 - [Vert.X Toolbox](https://github.com/vert-x3/vertx-microservices-toolbox) - A set of Vert.x components to build reactive microservice applications.
 - [Wangle](https://github.com/facebook/wangle) - A framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.
+- [Fission Workflows](https://github.com/fission/fission-workflows) - Workflow-based, reliable function composition for serverless functions.
 
 ## Service Toolkits
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Baratine](http://baratine.io/) - Platform for building a network of loosely-coupled POJO microservices.
 - [Erlang/OTP](https://github.com/erlang/otp) - Programming language used to build massively scalable soft real-time systems with requirements on high availability.
 - [Finagle](http://twitter.github.io/finagle) - Extensible RPC system for the JVM, used to construct high-concurrency servers.
+- [Fission Workflows](https://github.com/fission/fission-workflows) - Workflow-based, reliable function composition for serverless functions.
 - [GPars](https://github.com/GPars/GPars) - Concurrency and parallelism framework for the JVM.
 - [Grenache](https://github.com/bitfinexcom/grenache) - A Bittorent-DHT based microservices framework supporting REQ/REP and PUB/SUB patterns over multiple transports.
 - [Ice](https://zeroc.com/) - Comprehensive RPC framework with support for C++, C#, Java, JavaScript, Python, and more.
@@ -92,7 +93,6 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Vert.X](http://vertx.io/) - Toolkit for building reactive applications on the JVM.
 - [Vert.X Toolbox](https://github.com/vert-x3/vertx-microservices-toolbox) - A set of Vert.x components to build reactive microservice applications.
 - [Wangle](https://github.com/facebook/wangle) - A framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.
-- [Fission Workflows](https://github.com/fission/fission-workflows) - Workflow-based, reliable function composition for serverless functions.
 
 ## Service Toolkits
 


### PR DESCRIPTION
So, this is a bit of proposal. In my opinion FaaS deployments are a form of microservices, just with some stricter boundaries/characteristics. In its essence a FaaS function is a minimal microservice with the added benefit that it only runs on-demand.

Fission Workflows is a project aimed to allow composition of FaaS functions, allowing users to easily create complex distributed (micro)services using polygot languages. It basically takes away the otherwise complex communication logic between the cooperating services/functions.
 
I left out a link to [Fission](https://github.com/fission/fission) as I could not find the right place for it. Any opinions on that? 
