### PR TITLE
introduce scalecube-services a microservices lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Microserver](https://github.com/aol/micro-server) - Java 8 native, zero configuration, standards based, battle hardened library to run Java REST microservices.
 - [Orbit](http://orbit.bioware.com/) - Modern framework for JVM languages that makes it easier to build and maintain distributed and scalable online services.
 - [Quasar](https://github.com/puniverse/quasar) - Fibers, channels and actors for the JVM.
+- [ScaleCube](https://github.com/scalecube/scalecube) - Toolkit for building  Reactive microservices for the JVM: low-latency, high-throughput, scalable and resilient.
 - [Vert.X](http://vertx.io/) - Toolkit for building reactive applications on the JVM.
 - [Vert.X Toolbox](https://github.com/vert-x3/vertx-microservices-toolbox) - A set of Vert.x components to build reactive microservice applications.
 - [Wangle](https://github.com/facebook/wangle) - A framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Microserver](https://github.com/aol/micro-server) - Java 8 native, zero configuration, standards based, battle hardened library to run Java REST microservices.
 - [Orbit](http://orbit.bioware.com/) - Modern framework for JVM languages that makes it easier to build and maintain distributed and scalable online services.
 - [Quasar](https://github.com/puniverse/quasar) - Fibers, channels and actors for the JVM.
-- [ScaleCube](https://github.com/scalecube/scalecube) - Toolkit for building  Reactive microservices for the JVM: low-latency, high-throughput, scalable and resilient.
+- [ScaleCube](https://github.com/scalecube/scalecube) - Toolkit for building reactive microservices for the JVM: low-latency, high-throughput, scalable and resilient.
 - [Vert.X](http://vertx.io/) - Toolkit for building reactive applications on the JVM.
 - [Vert.X Toolbox](https://github.com/vert-x3/vertx-microservices-toolbox) - A set of Vert.x components to build reactive microservice applications.
 - [Wangle](https://github.com/facebook/wangle) - A framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.
@@ -325,7 +325,6 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Onyx](https://github.com/onyx-platform/onyx) - Distributed, masterless, high performance, fault tolerant data processing for Clojure.
 - [Ordasity](https://github.com/boundary/ordasity) - Designed to spread persistent or long-lived workloads across several machines.
 - [Redisson](https://github.com/mrniko/redisson) - Distributed and scalable Java data structures on top of Redis server.
-- [ScaleCube](http://scalecube.io) - SWIM and Gossip solution for cluster membership and failure detection. 
 - [Serf](https://www.serfdom.io/) - Decentralized solution for cluster membership, failure detection and orchestration.
 
 ### Job Schedulers / Workload Automation


### PR DESCRIPTION
Micro-services should start from a monolith-first approach as it hides risks and complexities. and trying to start from microservices on full scale almost never works. scalecube relief this pain as scaling becomes pure packaging issue and not development. with scalecube you are able to develop full distributed application locally. write once scale later approach.

ScaleCube is designed as an embeddable library for the Java VM. It is built in a modular way where each module independently implements a useful set of functionality and provides foundation for higher level features by abstracting away lower level concerns.

Next is described modules in the top to bottom order from the higher level features to the low level components.

**MICROSERVICES**

ScaleCube Services provides a low latency Reactive Microservices library for peer-to-peer service registry and discovery based on gossip protocol ad without single point-of-failure or bottlenecks.


```
<!-- https://mvnrepository.com/artifact/io.scalecube/scalecube-services -->
<dependency>
    <groupId>io.scalecube</groupId>
    <artifactId>scalecube-services</artifactId>
    <version>1.0.6</version>
</dependency>

```