### PR TITLE
Add Ecotone Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Swoft](https://github.com/swoft-cloud/swoft/) - PHP microservices coroutine framework for building high-performance web systems, APIs, middleware, and basic services.
 - [Symfony](https://symfony.com/) - Micro-framework based on the Symfony components.
 - [Upswarm](https://github.com/Zizaco/upswarm) - Multi-processed, async, fault-tolerant micro-framework for writing service-oriented applications.
+- [Ecotone](http://ecotone.tech) - Enables message driven architecture in PHP and provides building blocks to follow DDD and CQRS principles.
 
 ### Python
 


### PR DESCRIPTION
Add Ecotone Framework.

Overview:
The main idea behind Ecotone Framework is to separate business and integration logic. So the business logic is not influenced by technical problems.
Ecotone tries to achieve that by enabling message driven architecture in PHP and following architectural patterns based on DDD and CQRS.