### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,6 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Traffic Server](https://github.com/apache/trafficserver) - High-performance building block for cloud services.
 - [Tyk](https://tyk.io/) - Open source, fast and scalable API gateway, portal and API management platform.
 - [Vulcand](https://github.com/vulcand/vulcand) - Programmatic load balancer backed by Etcd.
-- [Zuul](https://github.com/Netflix/zuul) - An edge service that provides dynamic routing, monitoring, resiliency, security, and more.
 
 ### Configuration & Discovery
 


### PR DESCRIPTION
Zuul is no more an awesome API gateway when we have **Spring Cloud Gateway**. Zuul is a nonreactive, outdated Gateway. Zuul-2 debatable can be on the list, but the Spring and Java community has decided to stay away from it and redesign the API gateway. This is how the Spring Cloud Gateway came into play.