### PR TITLE
Add What Broke Today to Monitoring & Debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Zabbix](http://www.zabbix.com/) - Open source enterprise-class monitoring solution.
 - [Zipkin](http://zipkin.io) - Distributed tracing system.
 
+- [What Broke Today](https://whatbroke.today) - AI-powered outage aggregator tracking 100+ cloud services with real-time Telegram alerts.
 ### Reactivity
 
 - [Reactor.io](https://github.com/reactor) - A second-generation Reactive library for building non-blocking applications on the JVM based on the Reactive Streams Specification.


### PR DESCRIPTION
## Summary
- Adds [What Broke Today](https://whatbroke.today) to the Monitoring & Debugging section

## About What Broke Today
What Broke Today is an AI-powered outage aggregator that:
- Monitors 100+ cloud service status pages in real-time
- Uses AI to filter out maintenance/scheduled updates
- Sends instant alerts via Telegram
- Provides a clean web dashboard for browsing incidents

This tool helps teams monitor third-party dependencies in microservice architectures.

## Checklist
- [x] Link is working
- [x] Description follows existing format
- [x] Placed in appropriate section