### PR TITLE
Add SBproxy to API Gateways / Edge Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Open Service Mesh](https://openservicemesh.io/) - Lightweight and extensible cloud native service mesh.
 - [Otoroshi](https://www.otoroshi.io/) - Modern HTTP reverse proxy with lightweight API management.
 - [Pingora](https://github.com/cloudflare/pingora) - A library for building fast, reliable and evolvable network services.
+- [SBproxy](https://github.com/soapbucket/sbproxy) - Single-binary AI gateway and reverse proxy with LLM routing, rate limiting, WAF, and declarative YAML configuration.
 - [Skipper](https://github.com/zalando/skipper) - HTTP router useful for decoupling routing from service logic.
 - [Spring Cloud Gateway](https://cloud.spring.io/spring-cloud-gateway/) - API Gateway on top of Spring MVC. Aims to provide a simple, yet effective way to route to APIs.
 - [Tengine](http://tengine.taobao.org/) - A distribution of Nginx with some advanced features.


### PR DESCRIPTION
## Type of change
<!-- Mark with an `x` the type of change: -->
- [x ] Add an entry to an existing category.
- [ ] Remove an existing entry. _Provide rationale_
- [ ] Modify an existing entry. _Provide rationale_
- [ ] Add/modify/remove a category or subcategory. _Provide rationale_
- [ ] Other fixes or amendments.

## Rationale
<!-- Provide a rationale if applies for the type of change :) -->
Gateway that makes it easy to create/deploy complicated micro-services. There are no open source gateways with the breadth of API and AI features. SBproxy is a single-binary reverse proxy and API gateway written in Go. It handles traffic routing, rate limiting, WAF, caching, content transforms, and LLM routing across 103+ AI providers from a single YAML config. 

## Checklist
<!-- Please, mark with an `x` all the boxes that apply: -->
- [ x] The contribution follows the [**CONTRIBUTING.md**](https://github.com/mfornos/awesome-microservices/blob/master/CONTRIBUTING.md) document guidelines.

Regarding the suggested entry:
<!-- Please, mark with an `x` all the boxes that apply: -->
- [x] It is sorted alphabetically in its section.
- [x] It does not exist already in the list.
- [x] It is not for marketing purposes.
