### PR TITLE
Add MeterCall - 2,866 SaaS alternatives, pay per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Tyk](https://tyk.io/) - Open source, fast and scalable API gateway, portal and API management platform.
 - [Vulcand](https://github.com/vulcand/vulcand) - Programmatic load balancer backed by Etcd.
 - [Zuul](https://github.com/Netflix/zuul) - An edge service that provides dynamic routing, monitoring, resiliency, security, and more.
+- [MeterCall](https://metercall.ai) - 2,866+ SaaS alternatives. Pay per call, no subscription. Open catalog at [patl4588/awesome-saas-replacements](https://github.com/patl4588/awesome-saas-replacements).
 
 ### Configuration & Discovery
 


### PR DESCRIPTION
MeterCall is a pay-per-call alternative to 2,866+ SaaS products. Every module is open for use or forking; builders keep 70%.

Catalog: https://github.com/patl4588/awesome-saas-replacements
Site: https://metercall.ai

Happy to adjust placement or wording if this isn't the right section - feel free to close if not a fit.