### PR TITLE
Add KubeStellar Console to Monitoring & Debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [SkyWalking](https://skywalking.apache.org/) - Application performance monitor tool for distributed systems, especially designed for microservices, cloud native and container-based (Docker, K8s, Mesos) architectures.
 - [Zabbix](http://www.zabbix.com/) - Open source enterprise-class monitoring solution.
 - [Zipkin](http://zipkin.io) - Distributed tracing system.
+- [KubeStellar Console](https://console.kubestellar.io) - AI-powered multi-cluster Kubernetes dashboard with real-time observability, 150+ monitoring cards, and CNCF integrations.
 
 ### Reactivity
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://console.kubestellar.io) to the **Monitoring & Debugging** section under Capabilities.

KubeStellar Console is an open-source, AI-powered multi-cluster Kubernetes dashboard providing real-time observability across distributed microservices. It integrates with Prometheus, Grafana, Jaeger, OpenTelemetry, and 30+ CNCF projects for unified monitoring.

- 🔗 Live: https://console.kubestellar.io
- 📦 Source: https://github.com/kubestellar/console
- 📜 License: Apache-2.0
- 🏛️ CNCF Sandbox project (under KubeStellar)