### PR TITLE
Add tracemaid to Monitoring & Debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [SkyWalking](https://skywalking.apache.org/) - Application performance monitor tool for distributed systems, especially designed for microservices, cloud native and container-based (Docker, K8s, Mesos) architectures.
 - [Zabbix](http://www.zabbix.com/) - Open source enterprise-class monitoring solution.
 - [Zipkin](http://zipkin.io) - Distributed tracing system.
+- [tracemaid](https://github.com/karthyick/tracemaid) - Auto-generate Mermaid call graphs from OpenTelemetry traces. Visualizes microservice request paths, span timing, and parent-child relationships from existing OTel instrumentation.
 
 ### Reactivity
 


### PR DESCRIPTION
Adding [**tracemaid**](https://github.com/karthyick/tracemaid) under **Capabilities → Monitoring & Debugging**.

Tracemaid auto-generates **Mermaid call graphs from OpenTelemetry traces**, complementing existing tracing systems in this list (Jaeger, Zipkin, OpenTelemetry). Useful for:
- Visualizing microservice request paths from existing OTel instrumentation
- Debugging async workflows and long parent-child span chains
- Sharing call-graph snapshots in design docs (Mermaid renders natively in GitHub/GitLab)

- `pip install tracemaid`
- Python, MIT license
- Works with any OTel-instrumented service emitting standard OpenTelemetry spans

Thanks for maintaining this list!