### PR TITLE
Add Local Development subsection with mirrord

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of Microservice Architecture related principles and technologies.
   - [Workflow Orchestration](#workflow-orchestration)
   - [Elasticity](#elasticity)
   - [Job Schedulers / Workload Automation](#job-schedulers--workload-automation)
+  - [Local Development](#local-development)
   - [Logging](#logging)
   - [Messaging](#messaging)
   - [Monitoring & Debugging](#monitoring--debugging)
@@ -341,6 +342,10 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Faktory](https://github.com/contribsys/faktory) - Language-agnostic persistent background job server.
 - [Rundeck (c)](http://rundeck.org/) - Job scheduler and runbook automation. Enable self-service access to existing scripts and tools.
 - [Schedulix](https://github.com/schedulix/schedulix) - Open source enterprise job scheduling system lays down ground-breaking standards for the professional automation of IT processes in advanced system environments.
+
+### Local Development
+
+- [mirrord](https://metalbear.com/mirrord/) - Run local code as if it were a pod in a remote Kubernetes cluster.
 
 ### Logging
 


### PR DESCRIPTION
## What

Adds a new `Local Development` subsection under Capabilities, with mirrord as the seeding entry.

## Why

The list currently has no category for tools that connect local processes to remote microservice environments — what's commonly called the "inner loop" for microservices development. This is a real category with multiple established tools (Telepresence, Skaffold, Tilt, mirrord, Gefyra) that today have no clean home in this list.

The Capabilities subsections cover concerns like orchestration, discovery, messaging, monitoring, testing — Local Development fits the same pattern.

## About mirrord

mirrord is an open source tool that runs a local process as if it were a pod in a remote Kubernetes cluster, with real env vars, DNS, network, and inbound traffic. Lets developers iterate on a single microservice locally while interacting with the rest of the cluster's real services.

- Repo: https://github.com/metalbear-co/mirrord (5,059 stars, 57 contributors, MIT)
- Site: https://metalbear.com/mirrord/

## Format

Followed CONTRIBUTING.md (`[Name](link) - Short description.`, alphabetical position in TOC and section list, capitalized).

If you'd prefer to fit mirrord under the existing `Testing` subsection alongside Goreplay/Mitmproxy/Mountebank instead of adding a new section, happy to revise.