### PR TITLE
Add flakybin to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ A curated list of Microservice Architecture related principles and technologies.
 
 ### Testing
 
+- [flakybin](https://github.com/mikluko/flakybin) - A deterministic HTTP fault-injection server that fails endpoints (status codes, hangs, connection drops) on a seed-reproducible schedule to test uptime monitors and retry logic.
 - [Goreplay](https://github.com/buger/goreplay) - A tool for capturing and replaying live HTTP traffic into a test environment.
 - [Mitmproxy](https://mitmproxy.org/) - An interactive console program that allows traffic flows to be intercepted, inspected, modified and replayed.
 - [Mountebank](http://www.mbtest.org/) - Cross-platform, multi-protocol test doubles over the wire.


### PR DESCRIPTION
Adds [flakybin](https://github.com/mikluko/flakybin) to the Testing section.

flakybin is a deterministic HTTP fault-injection server: it fails endpoints (status codes, hangs, connection drops) on a seed-reproducible schedule, so you can point an uptime monitor or retry logic at a known-good failure pattern. Sits alongside Mountebank and Goreplay as HTTP test tooling. Open source (MIT).

- Individual PR for one suggestion
- Format: `[Name](link) - Short description.`
- Inserted in alphabetical order (before Goreplay)