### PR TITLE
Add MockServer to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ A curated list of Microservice Architecture related principles and technologies.
 - [Goreplay](https://github.com/buger/goreplay) - A tool for capturing and replaying live HTTP traffic into a test environment.
 - [Keploy](https://keploy.io) - Open-source tool for API testing and mocking by capturing real traffic and converting it into test cases and stubs, enabling reliable microservice testing.
 - [Mitmproxy](https://mitmproxy.org/) - An interactive console program that allows traffic flows to be intercepted, inspected, modified and replayed.
+- [MockServer](https://www.mock-server.com) - Mocking, debugging proxy and chaos engineering for multiple protocols (HTTP, gRPC, GraphQL, LLM, MCP, Kafka, TCP and more); mock dependencies, record/replay traffic, verify requests, and inject faults for integration and resilience testing.
 - [Mountebank](http://www.mbtest.org/) - Cross-platform, multi-protocol test doubles over the wire.
 - [Pact](https://docs.pact.io) - Contract testing framework for HTTP APIs and non-HTTP asynchronous messaging systems.
 - [RestQA](https://github.com/restqa/restqa) - A tool to manage microservices mocking, unit and performance testing locally with best in class developer experience.


### PR DESCRIPTION
Adds [MockServer](https://www.mock-server.com) to the **Testing** section.

MockServer is an open-source (Apache-2.0) HTTP(S)/REST/gRPC/LLM mock server and proxy used for integration and chaos testing — mock any dependency, record/replay traffic, verify requests, and inject faults. It runs as a Docker image, JAR, Helm chart, or embedded Java library, with clients for many languages.

- Source: https://github.com/mock-server/mockserver-monorepo
- Homepage/docs: https://www.mock-server.com

Checklist:
- [x] One item added, in the relevant section
- [x] Inserted in alphabetical order
- [x] Follows the list's entry format
- [x] Project is open-source and actively maintained