### PR TITLE
Add Apache APISIX to API Gateways / Edge Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A curated list of Microservice Architecture related principles and technologies.
 > Note that [data and control plane](https://blog.envoyproxy.io/service-mesh-data-plane-vs-control-plane-2774e720f7fc) components are not categorized at this moment.
 
 - [Ambassador (c)](https://www.getambassador.io) - Kubernetes-native API gateway for microservices built on Envoy.
+- [Apache APISIX](https://apisix.apache.org/) - High-performance, real-time API gateway and AI gateway built on NGINX and etcd, with hot-reloaded routing and 100+ plugins.
 - [APIcast](https://github.com/3scale/APIcast) - APIcast is an API gateway built on top of NGINX. It is part of the Red Hat 3scale API Management Platform.
 - [Bunker Web](https://github.com/bunkerity/bunkerweb) - Web app hosting and reverse proxy secure by default.
 - [Caddy](https://caddyserver.com/) - Extensible HTTP/2 web server with automatic HTTPS.


### PR DESCRIPTION
Adds **Apache APISIX** to the *API Gateways / Edge Services* section.

Apache APISIX is a top-level project of the Apache Software Foundation and a widely adopted open-source API gateway (16.7k+ GitHub stars, 320+ contributors) — a natural fit alongside the already-listed Kong, KrakenD, Tyk and Envoy.

- Inserted in alphabetical order (after Ambassador, before APIcast).
- Matches the existing `- [Name](url) - Description.` format.
- Fully open source (Apache-2.0), so no `(c)` marker.